### PR TITLE
Feature : Add charge/discharge threshold control support

### DIFF
--- a/components/fbot/fbot.h
+++ b/components/fbot/fbot.h
@@ -24,6 +24,8 @@ static const uint8_t REG_USB_CONTROL = 24;
 static const uint8_t REG_DC_CONTROL = 25;
 static const uint8_t REG_AC_CONTROL = 26;
 static const uint8_t REG_LIGHT_CONTROL = 27;
+static const uint8_t REG_THRESHOLD_DISCHARGE = 66;
+static const uint8_t REG_THRESHOLD_CHARGE = 67;
 
 // State flag bit masks for register 41
 static const uint16_t STATE_USB_BIT = 512;   // bit 9
@@ -53,6 +55,8 @@ class Fbot : public esphome::ble_client::BLEClientNode, public Component {
   void set_system_power_sensor(sensor::Sensor *sensor) { this->system_power_sensor_ = sensor; }
   void set_total_power_sensor(sensor::Sensor *sensor) { this->total_power_sensor_ = sensor; }
   void set_remaining_time_sensor(sensor::Sensor *sensor) { this->remaining_time_sensor_ = sensor; }
+  void set_threshold_charge_sensor(sensor::Sensor *sensor) { this->threshold_charge_sensor_ = sensor; }
+  void set_threshold_discharge_sensor(sensor::Sensor *sensor) { this->threshold_discharge_sensor_ = sensor; }
   
   // Binary sensor setters
   void set_connected_binary_sensor(binary_sensor::BinarySensor *sensor) { 
@@ -88,7 +92,11 @@ class Fbot : public esphome::ble_client::BLEClientNode, public Component {
   void control_dc(bool state);
   void control_ac(bool state);
   void control_light(bool state);
-  
+
+  // Control methods for thresholds
+  void set_threshold_charge(float percent);
+  void set_threshold_discharge(float percent);
+
   // Connection state getter
   bool is_connected() const { return connected_; }
   
@@ -120,6 +128,8 @@ class Fbot : public esphome::ble_client::BLEClientNode, public Component {
   sensor::Sensor *system_power_sensor_{nullptr};
   sensor::Sensor *total_power_sensor_{nullptr};
   sensor::Sensor *remaining_time_sensor_{nullptr};
+  sensor::Sensor *threshold_charge_sensor_{nullptr};
+  sensor::Sensor *threshold_discharge_sensor_{nullptr};
   
   // Binary sensors
   binary_sensor::BinarySensor *connected_binary_sensor_{nullptr};

--- a/components/fbot/number/__init__.py
+++ b/components/fbot/number/__init__.py
@@ -1,0 +1,67 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import number
+from esphome.const import (
+    CONF_ID,
+    CONF_ICON,
+    CONF_MIN_VALUE,
+    CONF_MAX_VALUE,
+    CONF_STEP,
+    UNIT_PERCENT,
+)
+from .. import fbot_ns, Fbot, CONF_FBOT_ID
+
+DEPENDENCIES = ["fbot"]
+
+CONF_THRESHOLD_CHARGE = "threshold_charge"
+CONF_THRESHOLD_DISCHARGE = "threshold_discharge"
+
+FbotNumber = fbot_ns.class_("FbotNumber", number.Number, cg.Component)
+
+NUMBER_TYPES = {
+    CONF_THRESHOLD_CHARGE: "threshold_charge",
+    CONF_THRESHOLD_DISCHARGE: "threshold_discharge",
+}
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_FBOT_ID): cv.use_id(Fbot),
+        cv.Optional(CONF_THRESHOLD_CHARGE): number.number_schema(
+            FbotNumber,
+            icon="mdi:battery-charging-100",
+            unit_of_measurement=UNIT_PERCENT,
+        ).extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=60): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=100): cv.float_,
+                cv.Optional(CONF_STEP, default=1): cv.float_,
+            }
+        ),
+        cv.Optional(CONF_THRESHOLD_DISCHARGE): number.number_schema(
+            FbotNumber,
+            icon="mdi:battery-outline",
+            unit_of_measurement=UNIT_PERCENT,
+        ).extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=50): cv.float_,
+                cv.Optional(CONF_STEP, default=1): cv.float_,
+            }
+        ),
+    }
+)
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_FBOT_ID])
+
+    for key, number_type in NUMBER_TYPES.items():
+        if key in config:
+            var = await number.new_number(
+                config[key],
+                min_value=config[key][CONF_MIN_VALUE],
+                max_value=config[key][CONF_MAX_VALUE],
+                step=config[key][CONF_STEP],
+            )
+            await cg.register_component(var, config[key])
+            cg.add(var.set_parent(parent))
+            cg.add(var.set_number_type(number_type))

--- a/components/fbot/number/fbot_number.cpp
+++ b/components/fbot/number/fbot_number.cpp
@@ -1,0 +1,51 @@
+#include "fbot_number.h"
+#include "esphome/core/log.h"
+
+#ifdef USE_ESP32
+
+namespace esphome {
+namespace fbot {
+
+static const char *const TAG = "fbot.number";
+
+void FbotNumber::setup() {
+  // Numbers start with no value until first update
+  this->publish_state(NAN);
+}
+
+void FbotNumber::dump_config() {
+  LOG_NUMBER("", "Fbot Number", this);
+  ESP_LOGCONFIG(TAG, "  Type: %s", this->number_type_.c_str());
+}
+
+void FbotNumber::control(float value) {
+  if (this->parent_ == nullptr) {
+    ESP_LOGW(TAG, "No parent set for number");
+    return;
+  }
+
+  // Check if device is connected before allowing changes
+  if (!this->parent_->is_connected()) {
+    ESP_LOGW(TAG, "Cannot change number '%s': device is disconnected", this->number_type_.c_str());
+    return;
+  }
+
+  // Call the appropriate control method based on number type
+  if (this->number_type_ == "threshold_charge") {
+    this->parent_->set_threshold_charge(value);
+  } else if (this->number_type_ == "threshold_discharge") {
+    this->parent_->set_threshold_discharge(value);
+  } else {
+    ESP_LOGW(TAG, "Unknown number type: %s", this->number_type_.c_str());
+    return;
+  }
+
+  // Publish the new value optimistically
+  // The actual value will be confirmed when the next status update arrives
+  this->publish_state(value);
+}
+
+}  // namespace fbot
+}  // namespace esphome
+
+#endif  // USE_ESP32

--- a/components/fbot/number/fbot_number.h
+++ b/components/fbot/number/fbot_number.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/number/number.h"
+#include "../fbot.h"
+
+#ifdef USE_ESP32
+
+namespace esphome {
+namespace fbot {
+
+class FbotNumber : public number::Number, public Component {
+ public:
+  void setup() override;
+  void dump_config() override;
+
+  void set_parent(Fbot *parent) { this->parent_ = parent; }
+  void set_number_type(const std::string &type) { this->number_type_ = type; }
+
+ protected:
+  void control(float value) override;
+
+  Fbot *parent_{nullptr};
+  std::string number_type_;
+};
+
+}  // namespace fbot
+}  // namespace esphome
+
+#endif  // USE_ESP32

--- a/components/fbot/sensor.py
+++ b/components/fbot/sensor.py
@@ -25,6 +25,8 @@ CONF_TOTAL_POWER = "total_power"
 CONF_REMAINING_TIME = "remaining_time"
 CONF_BATTERY_S1_LEVEL = "battery_s1_level"
 CONF_BATTERY_S2_LEVEL = "battery_s2_level"
+CONF_THRESHOLD_CHARGE = "threshold_charge"
+CONF_THRESHOLD_DISCHARGE = "threshold_discharge"
 
 CONFIG_SCHEMA = cv.Schema(
     {
@@ -77,6 +79,16 @@ CONFIG_SCHEMA = cv.Schema(
             device_class=DEVICE_CLASS_DURATION,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
+        cv.Optional(CONF_THRESHOLD_CHARGE): sensor.sensor_schema(
+            unit_of_measurement=UNIT_PERCENT,
+            accuracy_decimals=0,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_THRESHOLD_DISCHARGE): sensor.sensor_schema(
+            unit_of_measurement=UNIT_PERCENT,
+            accuracy_decimals=0,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
     }
 )
 
@@ -114,3 +126,11 @@ async def to_code(config):
     if CONF_REMAINING_TIME in config:
         sens = await sensor.new_sensor(config[CONF_REMAINING_TIME])
         cg.add(parent.set_remaining_time_sensor(sens))
+
+    if CONF_THRESHOLD_CHARGE in config:
+        sens = await sensor.new_sensor(config[CONF_THRESHOLD_CHARGE])
+        cg.add(parent.set_threshold_charge_sensor(sens))
+
+    if CONF_THRESHOLD_DISCHARGE in config:
+        sens = await sensor.new_sensor(config[CONF_THRESHOLD_DISCHARGE])
+        cg.add(parent.set_threshold_discharge_sensor(sens))

--- a/docs/example-basic.yaml
+++ b/docs/example-basic.yaml
@@ -91,6 +91,13 @@ sensor:
     remaining_time:
       name: "Remaining Minutes"
       id: remaining_minutes
+    # Optional sensors for charge/discharge thresholds
+    threshold_charge:
+      name: "Charge Threshold"
+      id: threshold_charge
+    threshold_discharge:
+      name: "Discharge Threshold"
+      id: threshold_discharge
   # Convert remaining time from minutes to hours
   - platform: template
     name: "Remaining Hours"
@@ -134,3 +141,20 @@ switch:
     light:
       name: "Light"
       id: light_switch
+
+# Number controls for charge/discharge thresholds
+number:
+  - platform: fbot
+    fbot_id: my_fbot
+    # Charge threshold: stop charging when battery reaches this level (60-100%)
+    threshold_charge:
+      name: "Charge Max"
+      min_value: 60
+      max_value: 100
+      step: 1
+    # Discharge threshold: stop discharging when battery reaches this level (0-50%)
+    threshold_discharge:
+      name: "Discharge Min"
+      min_value: 0
+      max_value: 50
+      step: 1

--- a/docs/example-m5atom-button.yaml
+++ b/docs/example-m5atom-button.yaml
@@ -99,6 +99,13 @@ sensor:
     remaining_time:
       name: "Remaining Minutes"
       id: remaining_minutes
+    # Optional sensors for charge/discharge thresholds
+    threshold_charge:
+      name: "Charge Threshold"
+      id: threshold_charge
+    threshold_discharge:
+      name: "Discharge Threshold"
+      id: threshold_discharge
   # Convert remaining time from minutes to hours
   - platform: template
     name: "Remaining Hours"
@@ -142,3 +149,20 @@ switch:
     light:
       name: "Light"
       id: light_switch
+
+# Number controls for charge/discharge thresholds
+number:
+  - platform: fbot
+    fbot_id: my_fbot
+    # Charge threshold: stop charging when battery reaches this level (60-100%)
+    threshold_charge:
+      name: "Charge Max"
+      min_value: 60
+      max_value: 100
+      step: 1
+    # Discharge threshold: stop discharging when battery reaches this level (0-50%)
+    threshold_discharge:
+      name: "Discharge Min"
+      min_value: 0
+      max_value: 50
+      step: 1

--- a/docs/example-m5atom-full.yaml
+++ b/docs/example-m5atom-full.yaml
@@ -119,6 +119,13 @@ sensor:
       internal: true
       name: "Remaining Minutes"
       id: remaining_minutes
+    # Optional sensors for charge/discharge thresholds
+    threshold_charge:
+      name: "Charge Threshold"
+      id: threshold_charge
+    threshold_discharge:
+      name: "Discharge Threshold"
+      id: threshold_discharge
   # Convert remaining time from minutes to hours
   - platform: template
     name: "Remaining Hours"
@@ -239,3 +246,20 @@ switch:
     light:
       name: "Light"
       id: light_switch
+
+# Number controls for charge/discharge thresholds
+number:
+  - platform: fbot
+    fbot_id: my_fbot
+    # Charge threshold: stop charging when battery reaches this level (60-100%)
+    threshold_charge:
+      name: "Charge Max"
+      min_value: 60
+      max_value: 100
+      step: 1
+    # Discharge threshold: stop discharging when battery reaches this level (0-50%)
+    threshold_discharge:
+      name: "Discharge Min"
+      min_value: 0
+      max_value: 50
+      step: 1

--- a/docs/example-m5atom-light-soc.yaml
+++ b/docs/example-m5atom-light-soc.yaml
@@ -138,6 +138,13 @@ sensor:
     remaining_time:
       name: "Remaining Minutes"
       id: remaining_minutes
+    # Optional sensors for charge/discharge thresholds
+    threshold_charge:
+      name: "Charge Threshold"
+      id: threshold_charge
+    threshold_discharge:
+      name: "Discharge Threshold"
+      id: threshold_discharge
   # Convert remaining time from minutes to hours
   - platform: template
     name: "Remaining Hours"
@@ -198,3 +205,20 @@ switch:
     light:
       name: "Light"
       id: light_switch
+
+# Number controls for charge/discharge thresholds
+number:
+  - platform: fbot
+    fbot_id: my_fbot
+    # Charge threshold: stop charging when battery reaches this level (60-100%)
+    threshold_charge:
+      name: "Charge Max"
+      min_value: 60
+      max_value: 100
+      step: 1
+    # Discharge threshold: stop discharging when battery reaches this level (0-50%)
+    threshold_discharge:
+      name: "Discharge Min"
+      min_value: 0
+      max_value: 50
+      step: 1

--- a/docs/example-m5atom-light-switch.yaml
+++ b/docs/example-m5atom-light-switch.yaml
@@ -114,6 +114,13 @@ sensor:
     remaining_time:
       name: "Remaining Minutes"
       id: remaining_minutes
+    # Optional sensors for charge/discharge thresholds
+    threshold_charge:
+      name: "Charge Threshold"
+      id: threshold_charge
+    threshold_discharge:
+      name: "Discharge Threshold"
+      id: threshold_discharge
   # Convert remaining time from minutes to hours
   - platform: template
     name: "Remaining Hours"
@@ -174,3 +181,20 @@ switch:
     light:
       name: "Light"
       id: light_switch
+
+# Number controls for charge/discharge thresholds
+number:
+  - platform: fbot
+    fbot_id: my_fbot
+    # Charge threshold: stop charging when battery reaches this level (60-100%)
+    threshold_charge:
+      name: "Charge Max"
+      min_value: 60
+      max_value: 100
+      step: 1
+    # Discharge threshold: stop discharging when battery reaches this level (0-50%)
+    threshold_discharge:
+      name: "Discharge Min"
+      min_value: 0
+      max_value: 50
+      step: 1


### PR DESCRIPTION
Hi,

I have added the implement of read/write support for battery charge (60-100%) and discharge (0-50%) thresholds. Adds threshold sensors and number controls exposed to Home Assistant.

Register mapping based on reverse engineering work from: https://github.com/iamslan/fossibot-reverse-engineering

I have tested and it work even though  that Home Assistant sorts the controls alphabetically.