### PR TITLE
Rename B2 parameters to B1 and update IDs

### DIFF
--- a/docs/example-basic-multi.yaml
+++ b/docs/example-basic-multi.yaml
@@ -110,7 +110,7 @@ sensor:
       name: "B1 DC Input Power"
       id: b1_dc_input_watts
     input_power:
-      name: "B2 Total Input Power"
+      name: "B1 Total Input Power"
       id: b1_input_watts
     output_power:
       name: "B1 Output Power"
@@ -127,10 +127,10 @@ sensor:
     # Optional sensors for charge/discharge thresholds
     threshold_charge:
       name: "B1 Charge Threshold"
-      id: threshold_charge
+      id: b1_threshold_charge
     threshold_discharge:
       name: "B1 Discharge Threshold"
-      id: threshold_discharge
+      id: b1_threshold_discharge
     charge_level:
       name: "B1 Charge Level"
   # Convert remaining time from minutes to hours
@@ -196,10 +196,10 @@ sensor:
     # Optional sensors for charge/discharge thresholds
     threshold_charge:
       name: "B2 Charge Threshold"
-      id: threshold_charge
+      id: b2_threshold_charge
     threshold_discharge:
       name: "B2 Discharge Threshold"
-      id: threshold_discharge
+      id: b2_threshold_discharge
     charge_level:
       name: "B2 Charge Level"
   # Convert remaining time from minutes to hours


### PR DESCRIPTION
This pull request updates the sensor configuration in `docs/example-basic-multi.yaml` which fixes a sensor naming and ID bug identified. The changes focus on correcting sensor names and making sensor IDs unique for each battery.

Sensor name correction:

* Updated the `input_power` sensor name from "B2 Total Input Power" to "B1 Total Input Power" to accurately reflect the associated battery.

Sensor ID consistency and uniqueness:

* Changed the IDs for `threshold_charge` and `threshold_discharge` sensors for Battery 1 to `b1_threshold_charge` and `b1_threshold_discharge`, respectively, ensuring unique identification.
* Changed the IDs for `threshold_charge` and `threshold_discharge` sensors for Battery 2 to `b2_threshold_charge` and `b2_threshold_discharge`, respectively, for consistency and uniqueness.